### PR TITLE
Configuration options for custom workflows; scalaJsResolverPlugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# https://editorconfig.org/
+
+root = true
+
+[*.ts]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -59,14 +59,19 @@ The plugin supports the following configuration options:
 export default defineConfig({
   plugins: [
     scalaJsSbtPlugin({
-      // path to the directory containing the sbt build
+      // Path to the directory containing the sbt build
       // default: '.'
       cwd: '.',
 
-      // sbt project ID from within the sbt build to get fast/fullLinkJS from
+      // Sbt project ID from within the sbt build to get fast/fullLinkJS from
       // default: the root project of the sbt build
       projectID: 'client',
 
+      // Custom sbt task to run. Must return the Scala.js output path,
+      // either as java.io.File, or as a String of its absolute path.
+      // default: either 'fastLinkJSOutput' or 'fullLinkJSOutput', depending on NODE_ENV.
+      task: 'fastLinkJSOutput',
+      
       // URI prefix of imports that this plugin catches (without the trailing ':')
       // default: 'scalajs' (so the plugin recognizes URIs starting with 'scalajs:')
       uriPrefix: 'scalajs',

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ export default defineConfig({
       // URI prefix of imports that this plugin catches (without the trailing ':')
       // default: 'scalajs' (so the plugin recognizes URIs starting with 'scalajs:')
       uriPrefix: 'scalajs',
+      
+      // This is how many times we will try to invoke sbt before giving up.
+      // Note: This applies only if sbt invocation fails for temporary reasons, i.e.:
+      //  1. If the sbt server was busy booting.
+      // default: 1 (no retries)
+      maxAttempts: 1,
+
+      // Delay between retries (if maxAttempts > 1)
+      // default: 1000 (1 second)
+      retryDelayMs: 1000
     }),
   ],
 });

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Tell Vite to use the plugin in `vite.config.js`:
 
 ```javascript
 import { defineConfig } from "vite";
-import scalaJSPlugin from "@scala-js/vite-plugin-scalajs";
+import scalaJsSbtPlugin from "@scala-js/vite-plugin-scalajs";
 
 export default defineConfig({
-  plugins: [scalaJSPlugin()],
+  plugins: [scalaJsSbtPlugin()],
 });
 ```
 
@@ -58,7 +58,7 @@ The plugin supports the following configuration options:
 ```javascript
 export default defineConfig({
   plugins: [
-    scalaJSPlugin({
+    scalaJsSbtPlugin({
       // path to the directory containing the sbt build
       // default: '.'
       cwd: '.',
@@ -83,6 +83,57 @@ export default defineConfig({
     }),
   ],
 });
+```
+
+## Resolver-only plugin
+
+We also offer a stripped down version of this vite plugin that does not call sbt. All it does is resolve module IDs with a `scalajs:` prefix to their full paths.
+
+You need to know the Scala.js output directory path to use this plugin (see `sbt show fastLinkJSOutput`). You don't want to hardcode this directory into your vite config, so this plugin is most suitable for custom sbt workflows, and integration with other Scala build tools.
+
+```javascript
+import { defineConfig } from "vite";
+import { scalaJsResolverPlugin } from "@scala-js/vite-plugin-scalajs";
+
+const scalaJsOutputDir = process.env.SCALAJS_OUTPUT_DIR;
+
+export default defineConfig({
+  plugins: [
+    scalaJsResolverPlugin({
+      // You MUST provide the directory where the scala.js output lives.
+      // default: none, will throw at build time if not provided. 
+      scalaJsOutputDir: scalaJsOutputDir,
+
+      // URI prefix of imports that this plugin catches (without the trailing ':')
+      // default: 'scalajs' (so the plugin recognizes URIs starting with 'scalajs:')
+      uriPrefix: "scalajs:"
+    })
+  ]
+})
+```
+
+You can also switch between the two plugins at build time. For example, inside your custom sbt task, you can run shell command `s"SCALAJS_OUTPUT_DIR=${fastLinkJsOutput.value} vite build"`, which would call into `scalaJsResolverPlugin` without booting another session of sbt, meanwhile you can use this same vite config to run `vite build` from the command line as usual:
+
+```javascript
+import { defineConfig } from "vite";
+import { scalaJsResolverPlugin, scalaJsSbtPlugin } from "@scala-js/vite-plugin-scalajs";
+
+const scalaJsOutputDir = process.env.SCALAJS_OUTPUT_DIR;
+
+const scalaJsPlugin = scalaJsOutputDir
+  ? scalaJsResolverPlugin({
+    scalaJsOutputDir: scalaJsOutputDir
+  })
+  : scalaJsSbtPlugin({
+    cwd: ".",
+    projectID: 'client',
+  }); 
+
+export default defineConfig({
+  plugins: [
+    scalaJsPlugin 
+  ]
+})
 ```
 
 ## Importing `@JSExportTopLevel` Scala.js members

--- a/index.ts
+++ b/index.ts
@@ -1,15 +1,16 @@
 import { spawn, SpawnOptions } from "child_process";
-import type { Plugin as VitePlugin } from "vite";
+import type { Logger, Plugin as VitePlugin } from "vite";
 
 // Utility to invoke a given sbt task and fetch its output
 function printSbtTask(
   task: string,
   cwd: string | undefined,
   maxAttempts: number,
-  retryDelayMs: number
+  retryDelayMs: number,
+  printWarning: (message: string) => void = printWarningFallback
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    printSbtTaskImpl(resolve, reject, task, cwd, maxAttempts, maxAttempts - 1, retryDelayMs);
+    printSbtTaskImpl(resolve, reject, task, cwd, maxAttempts, maxAttempts - 1, retryDelayMs, printWarning);
   });
 }
 
@@ -20,7 +21,8 @@ function printSbtTaskImpl(
   cwd: string | undefined,
   maxAttempts: number,
   remainingAttempts: number,
-  retryDelayMs: number
+  retryDelayMs: number,
+  warn: (message: string) => void
 ): void {
   if (remainingAttempts < 0) {
     reject(`ScalaJS Vite plugin: exhausted ${maxAttempts} sbt invocation attempts without catching the cause.`);
@@ -46,7 +48,7 @@ function printSbtTaskImpl(
   });
 
   child.on('error', err => {
-    reject(new Error(`sbt invocation for Scala.js compilation could not start. Is it installed? \n${err}`));
+    reject(new Error(`sbt invocation for Scala.js compilation could not start. Is it installed?\n${err}`));
   });
   child.on('close', code => {
     if (code !== 0) {
@@ -57,10 +59,10 @@ function printSbtTaskImpl(
         reject(new Error(errorMessage));
       } else if (fullOutput.includes("sbt thinks that server is already booting")) {
         if (remainingAttempts > 0) {
-          printWarning(`Sbt server is busy (booting), retrying in ${retryDelayMs} ms...`);
+          warn(`Sbt server is busy (booting), retrying in ${retryDelayMs} ms...`);
           setTimeout(
             () => {
-              printSbtTaskImpl(resolve, reject, task, cwd, maxAttempts, remainingAttempts - 1, retryDelayMs);
+              printSbtTaskImpl(resolve, reject, task, cwd, maxAttempts, remainingAttempts - 1, retryDelayMs, warn);
             },
             retryDelayMs
           );
@@ -78,7 +80,9 @@ function printSbtTaskImpl(
   });
 }
 
-function printWarning(message: String): void {
+// By default, we use Vite's Logger, as it takes into account user's logLevel preferences etc.
+// This function is a simple fallback if calling `printSbtTask` outside of Vite context.
+function printWarningFallback(message: String): void {
   const yellow = '\x1b[33m';
   const reset = '\x1b[0m';
   console.log(`${yellow}${message}${reset}`);
@@ -108,6 +112,7 @@ export function scalaJsSbtPlugin(options: ScalaJSPluginOptions = {}): VitePlugin
   const retryDelayMs = options.retryDelayMs ?? 1000;
 
   let isDev: boolean | undefined = undefined;
+  let logger: Logger | undefined = undefined;
   let scalaJsOutputDir: string | undefined = undefined;
 
   return {
@@ -116,13 +121,15 @@ export function scalaJsSbtPlugin(options: ScalaJSPluginOptions = {}): VitePlugin
     // Vite-specific
     configResolved(resolvedConfig) {
       isDev = resolvedConfig.mode === 'development';
+      logger = resolvedConfig.logger;
     },
 
     // standard Rollup
     async buildStart(buildOptions) {
-      if (isDev === undefined) {
+      if (isDev === undefined || logger === undefined) {
         throw new Error("configResolved must be called before buildStart");
       }
+      const resolvedLogger = logger;
 
       const task = options.task?.trim() || (isDev ? "fastLinkJSOutput" : "fullLinkJSOutput");
       if (["fastLinkJS", "fullLinkJS", "fastOptJS", "fullOptJS"].includes(task)) {
@@ -136,7 +143,10 @@ export function scalaJsSbtPlugin(options: ScalaJSPluginOptions = {}): VitePlugin
         throw new Error(errorMessage);
       }
       const projectTask = projectID ? `${projectID}/${task}` : task;
-      scalaJsOutputDir = await printSbtTask(projectTask, cwd, maxAttempts, retryDelayMs);
+      scalaJsOutputDir = await printSbtTask(
+        projectTask, cwd, maxAttempts, retryDelayMs,
+        message => resolvedLogger.warn(message)
+      );
     },
 
     // standard Rollup

--- a/index.ts
+++ b/index.ts
@@ -2,14 +2,34 @@ import { spawn, SpawnOptions } from "child_process";
 import type { Plugin as VitePlugin } from "vite";
 
 // Utility to invoke a given sbt task and fetch its output
-function printSbtTask(task: string, cwd?: string): Promise<string> {
+function printSbtTask(
+  task: string,
+  cwd: string | undefined,
+  maxAttempts: number,
+  retryDelayMs: number
+): Promise<string> {
+  return printSbtTaskImpl(task, cwd, maxAttempts, maxAttempts - 1, retryDelayMs);
+}
+
+function printSbtTaskImpl(
+  task: string,
+  cwd: string | undefined,
+  maxAttempts: number,
+  remainingAttempts: number,
+  retryDelayMs: number
+): Promise<string> {
+  if (remainingAttempts < 0) {
+    return Promise.reject(`ScalaJS Vite plugin: exhausted ${maxAttempts} sbt invocation attempts without catching the cause.`);
+  }
+
   const args = ["--batch", "-no-colors", "-Dsbt.supershell=false", `print ${task}`];
   const options: SpawnOptions = {
     cwd: cwd,
     stdio: ['ignore', 'pipe', 'inherit'],
   };
+
   const child = process.platform === 'win32'
-    ? spawn("sbt.bat", args.map(x => `"${x}"`), {shell: true, ...options})
+    ? spawn("sbt.bat", args.map(x => `"${x}"`), { shell: true, ...options })
     : spawn("sbt", args, options);
 
   let fullOutput: string = '';
@@ -22,7 +42,7 @@ function printSbtTask(task: string, cwd?: string): Promise<string> {
 
   return new Promise((resolve, reject) => {
     child.on('error', err => {
-      reject(new Error(`sbt invocation for Scala.js compilation could not start. Is it installed?\n${err}`));
+      reject(new Error(`sbt invocation for Scala.js compilation could not start. Is it installed? \n${err}`));
     });
     child.on('close', code => {
       if (code !== 0) {
@@ -30,8 +50,26 @@ function printSbtTask(task: string, cwd?: string): Promise<string> {
         if (fullOutput.includes("Not a valid command: --")) {
           errorMessage += "\nCause: Your sbt launcher script version is too old (<1.3.3)."
           errorMessage += "\nFix: Re-install the latest version of sbt launcher script from https://www.scala-sbt.org/"
+          reject(new Error(errorMessage));
+        } else if (fullOutput.includes("sbt thinks that server is already booting")) {
+          if (remainingAttempts > 0) {
+            printWarning(`Sbt server is busy (booting), retrying in ${retryDelayMs} ms...`);
+            setTimeout(
+              () => {
+                printSbtTaskImpl(task, cwd, maxAttempts, remainingAttempts -= 1, retryDelayMs)
+                  .then(resolve)
+                  .catch(reject);
+              },
+              retryDelayMs
+            );
+          } else {
+            // @TODO If we ever implement retries for different reasons, this error message could get misleading. Review then as needed.
+            errorMessage += `\nCause: Sbt thinks that server is already booting. ${maxAttempts} attempts failed.`;
+            reject(new Error(errorMessage));
+          }
+        } else {
+          reject(new Error(errorMessage));
         }
-        reject(new Error(errorMessage));
       } else {
         resolve(fullOutput.trimEnd().split('\n').at(-1)!);
       }
@@ -39,14 +77,25 @@ function printSbtTask(task: string, cwd?: string): Promise<string> {
   });
 }
 
+function printWarning(message: String): void {
+  const yellow = '\x1b[33m';
+  const reset = '\x1b[0m';
+  console.log(`${yellow}${message}${reset}`);
+}
+
 export interface ScalaJSPluginOptions {
   cwd?: string,
   projectID?: string,
   uriPrefix?: string,
+  maxAttempts?: number,
+  retryDelayMs?: number,
 }
 
 export default function scalaJSPlugin(options: ScalaJSPluginOptions = {}): VitePlugin {
   const { cwd, projectID, uriPrefix } = options;
+
+  const maxAttempts = options.maxAttempts ?? 1; // @TODO default to 3 in a future version?
+  const retryDelayMs = options.retryDelayMs ?? 1000;
 
   const fullURIPrefix = uriPrefix ? (uriPrefix + ':') : 'scalajs:';
 
@@ -68,7 +117,7 @@ export default function scalaJSPlugin(options: ScalaJSPluginOptions = {}): ViteP
 
       const task = isDev ? "fastLinkJSOutput" : "fullLinkJSOutput";
       const projectTask = projectID ? `${projectID}/${task}` : task;
-      scalaJSOutputDir = await printSbtTask(projectTask, cwd);
+      scalaJSOutputDir = await printSbtTask(projectTask, cwd, maxAttempts, retryDelayMs);
     },
 
     // standard Rollup

--- a/index.ts
+++ b/index.ts
@@ -91,16 +91,22 @@ export interface ScalaJSPluginOptions {
   retryDelayMs?: number,
 }
 
-export default function scalaJSPlugin(options: ScalaJSPluginOptions = {}): VitePlugin {
+export interface ScalaJSResolverPluginOptions {
+  scalaJsOutputDir: string,
+  uriPrefix?: string,
+}
+
+export default scalaJsSbtPlugin;
+
+// This version of the plugin calls sbt to find out `scalaJsOutputDir`.
+export function scalaJsSbtPlugin(options: ScalaJSPluginOptions = {}): VitePlugin {
   const { cwd, projectID, uriPrefix } = options;
 
   const maxAttempts = options.maxAttempts ?? 1; // @TODO default to 3 in a future version?
   const retryDelayMs = options.retryDelayMs ?? 1000;
 
-  const fullURIPrefix = uriPrefix ? (uriPrefix + ':') : 'scalajs:';
-
   let isDev: boolean | undefined = undefined;
-  let scalaJSOutputDir: string | undefined = undefined;
+  let scalaJsOutputDir: string | undefined = undefined;
 
   return {
     name: "scalajs:sbt-scalajs-plugin",
@@ -117,19 +123,55 @@ export default function scalaJSPlugin(options: ScalaJSPluginOptions = {}): ViteP
 
       const task = isDev ? "fastLinkJSOutput" : "fullLinkJSOutput";
       const projectTask = projectID ? `${projectID}/${task}` : task;
-      scalaJSOutputDir = await printSbtTask(projectTask, cwd, maxAttempts, retryDelayMs);
+      scalaJsOutputDir = await printSbtTask(projectTask, cwd, maxAttempts, retryDelayMs);
     },
 
     // standard Rollup
-    resolveId(source, importer, options) {
-      if (scalaJSOutputDir === undefined)
-        throw new Error("buildStart must be called before resolveId");
-
-      if (!source.startsWith(fullURIPrefix))
-        return null;
-      const path = source.substring(fullURIPrefix.length);
-
-      return `${scalaJSOutputDir}/${path}`;
+    resolveId(moduleId, importer, resolveOptions) {
+      return resolveModuleId(
+        moduleId,
+        uriPrefix,
+        scalaJsOutputDir,
+        "scalaJsSbtPlugin: buildStart must be called before resolveId"
+      );
     },
   };
+}
+
+// This version of the plugin does not call sbt, it only resolves the scala.js modules to a known `scalaJsOutputDir`.
+export function scalaJsResolverPlugin(options: ScalaJSResolverPluginOptions): VitePlugin {
+  return {
+    name: "scalajs:resolver-plugin",
+
+    // standard Rollup
+    resolveId(moduleId, importer, resolveOptions) {
+      return resolveModuleId(
+        moduleId,
+        options?.uriPrefix,
+        options?.scalaJsOutputDir,
+        "You must provide a `scalaJsOutputDir` option to scalaJsResolverPlugin (or use scalaJsSbtPlugin, which calls sbt to find it)."
+      );
+    },
+  };
+}
+
+// Returns null if the module id is not relevant to scala.js vite plugin.
+// Throws if scalaJsOutputDir is not defined.
+export function resolveModuleId(
+  moduleId: String,
+  uriPrefix: string | undefined,
+  scalaJsOutputDir: string | undefined,
+  errorMessageIfNoOutputDir: string
+): string | null {
+  if (scalaJsOutputDir === undefined)
+    throw new Error(errorMessageIfNoOutputDir);
+
+  const fullUriPrefix = uriPrefix ? (uriPrefix + ':') : 'scalajs:';
+
+  if (!moduleId.startsWith(fullUriPrefix))
+    return null;
+
+  const path = moduleId.substring(fullUriPrefix.length);
+
+  return `${scalaJsOutputDir}/${path}`;
 }

--- a/index.ts
+++ b/index.ts
@@ -49,7 +49,7 @@ function printSbtTaskImpl(
         let errorMessage = `sbt invocation for Scala.js compilation failed with exit code ${code}.`;
         if (fullOutput.includes("Not a valid command: --")) {
           errorMessage += "\nCause: Your sbt launcher script version is too old (<1.3.3)."
-          errorMessage += "\nFix: Re-install the latest version of sbt launcher script from https://www.scala-sbt.org/"
+          errorMessage += "\nFix:   Re-install the latest version of sbt launcher script from https://www.scala-sbt.org/"
           reject(new Error(errorMessage));
         } else if (fullOutput.includes("sbt thinks that server is already booting")) {
           if (remainingAttempts > 0) {
@@ -86,6 +86,7 @@ function printWarning(message: String): void {
 export interface ScalaJSPluginOptions {
   cwd?: string,
   projectID?: string,
+  task?: string,
   uriPrefix?: string,
   maxAttempts?: number,
   retryDelayMs?: number,
@@ -117,11 +118,22 @@ export function scalaJsSbtPlugin(options: ScalaJSPluginOptions = {}): VitePlugin
     },
 
     // standard Rollup
-    async buildStart(options) {
-      if (isDev === undefined)
+    async buildStart(buildOptions) {
+      if (isDev === undefined) {
         throw new Error("configResolved must be called before buildStart");
+      }
 
-      const task = isDev ? "fastLinkJSOutput" : "fullLinkJSOutput";
+      const task = options.task?.trim() || (isDev ? "fastLinkJSOutput" : "fullLinkJSOutput");
+      if (["fastLinkJS", "fullLinkJS", "fastOptJS", "fullOptJS"].includes(task)) {
+        // Warn about known-bad tasks to help users out
+        let errorMessage = `scalaJsSbtPlugin: you provided a known unsupported task '${task}'.`;
+        errorMessage += "\nFix: Provide either 'fastLinkJSOutput' or 'fullLinkJSOutput'.";
+        errorMessage += "\n     One of those is probably what you want.";
+        errorMessage += "\n     By default, the plugin chooses between them depending on NODE_ENV.";
+        errorMessage += "\nOr:  Provide a custom task that returns the Scala.js output directory,";
+        errorMessage += "\n     either as a java.io.File, or as a String with its absolute path.";
+        throw new Error(errorMessage);
+      }
       const projectTask = projectID ? `${projectID}/${task}` : task;
       scalaJsOutputDir = await printSbtTask(projectTask, cwd, maxAttempts, retryDelayMs);
     },
@@ -163,13 +175,15 @@ export function resolveModuleId(
   scalaJsOutputDir: string | undefined,
   errorMessageIfNoOutputDir: string
 ): string | null {
-  if (scalaJsOutputDir === undefined)
+  if (scalaJsOutputDir === undefined) {
     throw new Error(errorMessageIfNoOutputDir);
+  }
 
   const fullUriPrefix = uriPrefix ? (uriPrefix + ':') : 'scalajs:';
 
-  if (!moduleId.startsWith(fullUriPrefix))
+  if (!moduleId.startsWith(fullUriPrefix)) {
     return null;
+  }
 
   const path = moduleId.substring(fullUriPrefix.length);
 

--- a/index.ts
+++ b/index.ts
@@ -8,18 +8,23 @@ function printSbtTask(
   maxAttempts: number,
   retryDelayMs: number
 ): Promise<string> {
-  return printSbtTaskImpl(task, cwd, maxAttempts, maxAttempts - 1, retryDelayMs);
+  return new Promise((resolve, reject) => {
+    printSbtTaskImpl(resolve, reject, task, cwd, maxAttempts, maxAttempts - 1, retryDelayMs);
+  });
 }
 
 function printSbtTaskImpl(
+  resolve: (value: string) => void,
+  reject: (reason?: any) => void,
   task: string,
   cwd: string | undefined,
   maxAttempts: number,
   remainingAttempts: number,
   retryDelayMs: number
-): Promise<string> {
+): void {
   if (remainingAttempts < 0) {
-    return Promise.reject(`ScalaJS Vite plugin: exhausted ${maxAttempts} sbt invocation attempts without catching the cause.`);
+    reject(`ScalaJS Vite plugin: exhausted ${maxAttempts} sbt invocation attempts without catching the cause.`);
+    return;
   }
 
   const args = ["--batch", "-no-colors", "-Dsbt.supershell=false", `print ${task}`];
@@ -40,40 +45,36 @@ function printSbtTaskImpl(
     process.stdout.write(data); // tee on my own stdout
   });
 
-  return new Promise((resolve, reject) => {
-    child.on('error', err => {
-      reject(new Error(`sbt invocation for Scala.js compilation could not start. Is it installed? \n${err}`));
-    });
-    child.on('close', code => {
-      if (code !== 0) {
-        let errorMessage = `sbt invocation for Scala.js compilation failed with exit code ${code}.`;
-        if (fullOutput.includes("Not a valid command: --")) {
-          errorMessage += "\nCause: Your sbt launcher script version is too old (<1.3.3)."
-          errorMessage += "\nFix:   Re-install the latest version of sbt launcher script from https://www.scala-sbt.org/"
-          reject(new Error(errorMessage));
-        } else if (fullOutput.includes("sbt thinks that server is already booting")) {
-          if (remainingAttempts > 0) {
-            printWarning(`Sbt server is busy (booting), retrying in ${retryDelayMs} ms...`);
-            setTimeout(
-              () => {
-                printSbtTaskImpl(task, cwd, maxAttempts, remainingAttempts -= 1, retryDelayMs)
-                  .then(resolve)
-                  .catch(reject);
-              },
-              retryDelayMs
-            );
-          } else {
-            // @TODO If we ever implement retries for different reasons, this error message could get misleading. Review then as needed.
-            errorMessage += `\nCause: Sbt thinks that server is already booting. ${maxAttempts} attempts failed.`;
-            reject(new Error(errorMessage));
-          }
+  child.on('error', err => {
+    reject(new Error(`sbt invocation for Scala.js compilation could not start. Is it installed? \n${err}`));
+  });
+  child.on('close', code => {
+    if (code !== 0) {
+      let errorMessage = `sbt invocation for Scala.js compilation failed with exit code ${code}.`;
+      if (fullOutput.includes("Not a valid command: --")) {
+        errorMessage += "\nCause: Your sbt launcher script version is too old (<1.3.3)."
+        errorMessage += "\nFix:   Re-install the latest version of sbt launcher script from https://www.scala-sbt.org/"
+        reject(new Error(errorMessage));
+      } else if (fullOutput.includes("sbt thinks that server is already booting")) {
+        if (remainingAttempts > 0) {
+          printWarning(`Sbt server is busy (booting), retrying in ${retryDelayMs} ms...`);
+          setTimeout(
+            () => {
+              printSbtTaskImpl(resolve, reject, task, cwd, maxAttempts, remainingAttempts - 1, retryDelayMs);
+            },
+            retryDelayMs
+          );
         } else {
+          // @TODO If we ever implement retries for different reasons, this error message could get misleading. Review then as needed.
+          errorMessage += `\nCause: Sbt thinks that server is already booting. ${maxAttempts} attempts failed.`;
           reject(new Error(errorMessage));
         }
       } else {
-        resolve(fullOutput.trimEnd().split('\n').at(-1)!);
+        reject(new Error(errorMessage));
       }
-    });
+    } else {
+      resolve(fullOutput.trimEnd().split('\n').at(-1)!);
+    }
   });
 }
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, TestOptions } from 'vitest';
 import scalaJSPlugin, { ScalaJSPluginOptions } from "../index";
 import type { PluginContext } from 'rollup';
-import type { Plugin as VitePlugin } from "vite";
+import { createLogger, type Logger, type Plugin as VitePlugin } from "vite";
 
 /* This interface refines the VitePlugin with some knowledge about our
  * particular implementation, for easier testing. If we define here something
@@ -9,7 +9,7 @@ import type { Plugin as VitePlugin } from "vite";
  * we do get some safety that we adhere to VitePlugin's API.
  */
 interface RefinedPlugin extends VitePlugin {
-  configResolved: (this: void, resolvedConfig: { mode: string }) => void | Promise<void>;
+  configResolved: (this: void, resolvedConfig: { mode: string, logger: Logger }) => void | Promise<void>;
   buildStart: (this: PluginContext, options: {}) => void | Promise<void>;
   resolveId: (this: PluginContext, source: string) => string | Promise<string>;
 }
@@ -20,6 +20,8 @@ function normalizeSlashes(path: string | null): string | null {
 
 const MODE_DEVELOPMENT = 'development';
 const MODE_PRODUCTION = 'production';
+
+const logger = createLogger();
 
 describe("scalaJSPlugin", () => {
   const cwd = process.cwd() + "/test/testproject";
@@ -49,7 +51,7 @@ describe("scalaJSPlugin", () => {
   it("works without a specific projectID (production)", testOptions, async () => {
     const [plugin, fakePluginContext] = setup({});
 
-    await plugin.configResolved.call(undefined, { mode: MODE_PRODUCTION });
+    await plugin.configResolved.call(undefined, { mode: MODE_PRODUCTION, logger: logger });
     await plugin.buildStart.call(fakePluginContext, {});
 
     expect(normalizeSlashes(await plugin.resolveId.call(fakePluginContext, 'scalajs:main.js')))
@@ -62,7 +64,7 @@ describe("scalaJSPlugin", () => {
   it("works without a specific projectID (development)", testOptions, async () => {
     const [plugin, fakePluginContext] = setup({});
 
-    await plugin.configResolved.call(undefined, { mode: MODE_DEVELOPMENT });
+    await plugin.configResolved.call(undefined, { mode: MODE_DEVELOPMENT, logger: logger });
     await plugin.buildStart.call(fakePluginContext, {});
 
     expect(normalizeSlashes(await plugin.resolveId.call(fakePluginContext, 'scalajs:main.js')))
@@ -77,7 +79,7 @@ describe("scalaJSPlugin", () => {
       projectID: "otherProject",
     });
 
-    await plugin.configResolved.call(undefined, { mode: MODE_PRODUCTION });
+    await plugin.configResolved.call(undefined, { mode: MODE_PRODUCTION, logger: logger });
     await plugin.buildStart.call(fakePluginContext, {});
 
     expect(normalizeSlashes(await plugin.resolveId.call(fakePluginContext, 'scalajs:main.js')))
@@ -92,7 +94,7 @@ describe("scalaJSPlugin", () => {
       uriPrefix: "customsjs",
     });
 
-    await plugin.configResolved.call(undefined, { mode: MODE_DEVELOPMENT });
+    await plugin.configResolved.call(undefined, { mode: MODE_DEVELOPMENT, logger: logger });
     await plugin.buildStart.call(fakePluginContext, {});
 
     expect(normalizeSlashes(await plugin.resolveId.call(fakePluginContext, 'customsjs:main.js')))
@@ -107,7 +109,7 @@ describe("scalaJSPlugin", () => {
       projectID: "invalidProject",
     });
 
-    await plugin.configResolved.call(undefined, { mode: MODE_PRODUCTION });
+    await plugin.configResolved.call(undefined, { mode: MODE_PRODUCTION, logger: logger });
 
     const buildStartResult = plugin.buildStart.call(fakePluginContext, {});
     await expect(buildStartResult).rejects.toThrowError('sbt invocation');


### PR DESCRIPTION
I've been looking into using Scala.js in Electron, and needed additional functionality from the vite plugin to support Electron's development workflow... or maybe just my flavor of it. Unlike typical frontend development, there's a node.js component that needs to be integrated with `fastLinkJS + vite build` rather than the vite dev server; the proposed features stem from me trying to wrangle a custom workflow that would work nicely. I think the end result could be broadly useful for custom workflow in general.

I believe everything in this PR is backwards compatible, there should be no breaking changes to users.

## New features:
- Introduced optional `task` plugin option where you can specify `fastLinkJSOutput` or `fullLinkJSOutput` (or a custom command) to decouple this from `NODE_ENV` (default remains the same).
- Introduced retries of sbt invocation, to add resilience against "sbt thinks that server is already booting" exceptions.
  - This error can happen if you try to launch multiple sbt sessions at the same time, e.g. `concurrently 'vite build this' 'vite build that'`. This can be avoided by sleeping, but it's nicer when it just works.
  - To maintain current behaviour, the retries are opt-in by setting `maxAttempts` option. If you're ok to change behaviour, we could set the default `maxAttempts` to 3.
- Introduced a new `scalaJsResolverPlugin` that is exported separately. All it does is resolve the `scalajs:` prefix to the scala.js output path that the user needs to provide.
  - This is useful when you know the scala.js output path, and don't want to invoke sbt – for example, if you're calling `vite build` from within sbt already. Or I guess from another build tool.
  - That resolver plugin is deathly simple, but the new example in the docs shows why it's convenient to have it published together with the scala.js sbt plugin
  - I decided to make it a separate plugin rather than a configuration option to the main plugin to make it more obvious what's happening in the vite config file. If it was all one plugin, most of the configuration options would apply only conditionally depending on the value of one of the configuration option, would be confusing I think. And the two plugins do perform their tasks sufficiently differently, that I think separating them is just clearer, both in the API and in the implementation.
- More details on the above in the README diff

## Technical changes
- Renamed the main plugin function name from `scalaJSPlugin` to `scalaJsSbtPlugin`:
  - Added `sbt` to differentiate from the other plugin
  - Title-cased `JS` to `Js` because it's hard to have good camel case names with uppercase acronyms (`scalaJSSbtPlugin`, `scalaJSSBTPlugin` are all less readable). I tend to treat acronyms as if they were words when camelCase-ing, makes naming (and reading) easier.
  - This does not affect existing API as you exported this function as a default export, which comes without a name
  - But if you want to use both `scalaJsSbtPlugin` and `scalaJsResolverPlugin` then the new naming becomes relevant and is self-consistent.
  - I kept uppercase `JS` in the type names of the *Options interfaces to avoid any potential breakage in the public API. Would be nice to convert those to `Js` for consistency later.
 - Added spaces within braces `{ shell: true, ...options }` to make it consistent with other code. Don't have a preference either way, just wanted to give IDEA a chance to format the file without causing edits.
 - Added .editorConfig file to specify the expected 2-space indent, for same reason.

Hopefully the above decisions are acceptable, these individual features were too small to make PRs individually, so I yolo-d on bundling them. But if something here is not agreeable, let me know of course.