### PR TITLE
feat(sbt): add "--server"

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import type { Plugin as VitePlugin } from "vite";
 
 // Utility to invoke a given sbt task and fetch its output
 function printSbtTask(task: string, cwd?: string): Promise<string> {
-  const args = ["--batch", "-no-colors", "-Dsbt.supershell=false", `print ${task}`];
+  const args = ["--server", "--batch", "-no-colors", "-Dsbt.supershell=false", `print ${task}`];
   const options: SpawnOptions = {
     cwd: cwd,
     stdio: ['ignore', 'pipe', 'inherit'],


### PR DESCRIPTION
- Add `--server` flag to sbt command arguments to run sbt server in foreground.

sbt 2 by default runs sbtn (thin client)