### PR TITLE
Use a temporary file for sbt task output.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,39 +12,20 @@ async function printSbtTask(task: string, cwd?: string): Promise<string> {
 
   /* Converts a string to its representation as a Scala string literal, in a
    * way that is safe to use in a shell argument.
-   * On Windows, makes extra effort to avoid any quote or parentheses appearing
-   * in the output, to work around https://github.com/sbt/sbt/issues/9660.
    */
   function scalaString(s: string): string {
-    if (process.platform === 'win32') {
-      // Example: "AB" -> {65::66::Nil}.map{_.toChar}.mkString
-      let result = '{';
-      for (let i = 0; i < s.length; i++) {
-        result += s.charCodeAt(i);
-        result += '::'
-      }
-      result += 'Nil}.map{_.toChar}.mkString';
-      return result;
-    } else {
-      // Escape problematic characters using their \uxxxx representation
-      const escaped = s.replace(/[\u0000- \\"']/g,
-        (c) => "\\u" + c.charCodeAt(0).toString(16).padStart(4, "0"));
-      return '"' + escaped + '"';
-    }
+    // Escape problematic characters using their \uxxxx representation
+    const escaped = s.replace(/[\u0000- \\"']/g,
+      (c) => "\\u" + c.charCodeAt(0).toString(16).padStart(4, "0"));
+    return '"' + escaped + '"';
   }
 
   try {
-    /* The atrocious incantation in the 'set' argument avoids quotes and
-     * parentheses. This works around https://github.com/sbt/sbt/issues/9660.
-     * To do that, we must only use method calls with exactly 1 argument, which
-     * we can call with {} instead of (), or with no argument list at all.
-     * We abuse the fact that .close works because it's a Java method.
-     */
     const args = [
       "--batch",
       "-no-colors",
       "-Dsbt.supershell=false",
-      `set TaskKey[Unit]{${scalaString('dummy')}} := { val os = java.nio.file.Files.newOutputStream{file{${scalaString(myTmpFile)}}.toPath}; os.write{{${task}}.value.toString.getBytes{java.nio.charset.StandardCharsets.UTF_8}}; os.close }`,
+      `set TaskKey[Unit](${scalaString('dummy')}) := sbt.IO.write(file(${scalaString(myTmpFile)}), (${task}).value.toString, java.nio.charset.StandardCharsets.UTF_8)`,
       "dummy"
     ];
     const options: SpawnOptions = {
@@ -52,7 +33,7 @@ async function printSbtTask(task: string, cwd?: string): Promise<string> {
       stdio: ['ignore', 'pipe', 'inherit'],
     };
     const child = process.platform === 'win32'
-        ? spawn("sbt.bat", args.map(x => `"${x}"`), { shell: true, ...options })
+        ? spawn("sbt.bat", args.map(x => `"${x.replace(/"/g, '""')}"`), { shell: true, ...options })
         : spawn("sbt", args, options);
 
     let fullOutput: string = '';

--- a/index.ts
+++ b/index.ts
@@ -1,42 +1,91 @@
-import { spawn, SpawnOptions } from "child_process";
+import { spawn, SpawnOptions } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile, rmdir, rm } from "node:fs/promises";
 import type { Plugin as VitePlugin } from "vite";
 
 // Utility to invoke a given sbt task and fetch its output
-function printSbtTask(task: string, cwd?: string): Promise<string> {
-  const args = ["--batch", "-no-colors", "-Dsbt.supershell=false", `print ${task}`];
-  const options: SpawnOptions = {
-    cwd: cwd,
-    stdio: ['ignore', 'pipe', 'inherit'],
-  };
-  const child = process.platform === 'win32'
-    ? spawn("sbt.bat", args.map(x => `"${x}"`), {shell: true, ...options})
-    : spawn("sbt", args, options);
+async function printSbtTask(task: string, cwd?: string): Promise<string> {
+  const baseTmp = os.tmpdir();
+  const myTmp = await mkdtemp(path.join(baseTmp, "scalajs-vite-plugin-"));
+  const myTmpFile = path.join(myTmp, "out");
 
-  let fullOutput: string = '';
-
-  child.stdout!.setEncoding('utf-8');
-  child.stdout!.on('data', data => {
-    fullOutput += data;
-    process.stdout.write(data); // tee on my own stdout
-  });
-
-  return new Promise((resolve, reject) => {
-    child.on('error', err => {
-      reject(new Error(`sbt invocation for Scala.js compilation could not start. Is it installed?\n${err}`));
-    });
-    child.on('close', code => {
-      if (code !== 0) {
-        let errorMessage = `sbt invocation for Scala.js compilation failed with exit code ${code}.`;
-        if (fullOutput.includes("Not a valid command: --")) {
-          errorMessage += "\nCause: Your sbt launcher script version is too old (<1.3.3)."
-          errorMessage += "\nFix: Re-install the latest version of sbt launcher script from https://www.scala-sbt.org/"
-        }
-        reject(new Error(errorMessage));
-      } else {
-        resolve(fullOutput.trimEnd().split('\n').at(-1)!);
+  /* Converts a string to its representation as a Scala string literal, in a
+   * way that is safe to use in a shell argument.
+   * On Windows, makes extra effort to avoid any quote or parentheses appearing
+   * in the output, to work around https://github.com/sbt/sbt/issues/9660.
+   */
+  function scalaString(s: string): string {
+    if (process.platform === 'win32') {
+      // Example: "AB" -> {65::66::Nil}.map{_.toChar}.mkString
+      let result = '{';
+      for (let i = 0; i < s.length; i++) {
+        result += s.charCodeAt(i);
+        result += '::'
       }
+      result += 'Nil}.map{_.toChar}.mkString';
+      return result;
+    } else {
+      // Escape problematic characters using their \uxxxx representation
+      const escaped = s.replace(/[\u0000- \\"']/g,
+        (c) => "\\u" + c.charCodeAt(0).toString(16).padStart(4, "0"));
+      return '"' + escaped + '"';
+    }
+  }
+
+  try {
+    /* The atrocious incantation in the 'set' argument avoids quotes and
+     * parentheses. This works around https://github.com/sbt/sbt/issues/9660.
+     * To do that, we must only use method calls with exactly 1 argument, which
+     * we can call with {} instead of (), or with no argument list at all.
+     * We abuse the fact that .close works because it's a Java method.
+     */
+    const args = [
+      "--batch",
+      "-no-colors",
+      "-Dsbt.supershell=false",
+      `set TaskKey[Unit]{${scalaString('dummy')}} := { val os = java.nio.file.Files.newOutputStream{file{${scalaString(myTmpFile)}}.toPath}; os.write{{${task}}.value.toString.getBytes{java.nio.charset.StandardCharsets.UTF_8}}; os.close }`,
+      "dummy"
+    ];
+    const options: SpawnOptions = {
+      cwd: cwd,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    };
+    const child = process.platform === 'win32'
+        ? spawn("sbt.bat", args.map(x => `"${x}"`), { shell: true, ...options })
+        : spawn("sbt", args, options);
+
+    let fullOutput: string = '';
+
+    child.stdout!.setEncoding('utf-8');
+    child.stdout!.on('data', data => {
+      fullOutput += data;
+      process.stdout.write(data); // tee on my own stdout
     });
-  });
+
+    await new Promise<void>((resolve, reject) => {
+      child.on('error', err => {
+        reject(new Error(`sbt invocation for Scala.js compilation could not start. Is it installed?\n${err}`));
+      });
+      child.on('close', code => {
+        if (code !== 0) {
+          let errorMessage = `sbt invocation for Scala.js compilation failed with exit code ${code}.`;
+          if (fullOutput.includes("Not a valid command: --")) {
+            errorMessage += "\nCause: Your sbt launcher script version is too old (<1.3.3)."
+            errorMessage += "\nFix: Re-install the latest version of sbt launcher script from https://www.scala-sbt.org/"
+          }
+          reject(new Error(errorMessage));
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    return await readFile(myTmpFile, 'utf-8');
+  } finally {
+    await rm(myTmpFile, { force: true });
+    await rmdir(myTmp);
+  }
 }
 
 export interface ScalaJSPluginOptions {
@@ -67,7 +116,7 @@ export default function scalaJSPlugin(options: ScalaJSPluginOptions = {}): ViteP
         throw new Error("configResolved must be called before buildStart");
 
       const task = isDev ? "fastLinkJSOutput" : "fullLinkJSOutput";
-      const projectTask = projectID ? `${projectID}/${task}` : task;
+      const projectTask = projectID ? `${projectID}/Compile/${task}` : `Compile/${task}`;
       scalaJSOutputDir = await printSbtTask(projectTask, cwd);
     },
 


### PR DESCRIPTION
Possibly replaces #20 and #37. Not an SBT wizard so this needs some checking by someone more experienced :smile: 

This replaces parsing SBT's output with instead telling SBT to write to a temporary file that the Vite plugin creates using standard NodeJS APIs (os.tmpdir, fs.mkdtemp). Since one can't `eval IO.write(..., someTask.value)` plainly as an SBT command (to my knowledge), instead I create a task that depends on the `someTask` and immediately invoke it.